### PR TITLE
Add a script to setup a development environment for EasyBuild

### DIFF
--- a/scripts/install-EasyBuild-develop.sh
+++ b/scripts/install-EasyBuild-develop.sh
@@ -12,7 +12,7 @@ print_usage()
 {
     echo "Usage: $0 github_username install_directory"
     echo
-    echo "    github_username:     username on GitHub for which the easybuild repositories have been cloned"
+    echo "    github_username:     username on GitHub for which the easybuild repositories should be cloned"
     echo
     echo "    install_directory:   directory were all the EasyBuild files will be installed"
     echo
@@ -37,7 +37,7 @@ github_clone_branch()
     if [ "$BRANCH" != "master" ] ; then
         echo "=== Checking out the '${BRANCH}' branch"
         git branch --track "${BRANCH}" "github_hpcugent/${BRANCH}"
-    	git checkout "${BRANCH}"
+        git checkout "${BRANCH}"
     fi
 }
 


### PR DESCRIPTION
This script:
- clone all the EB repositories
- checkout the develop branch in eb-framework, eb-easyblocks and eb-easyconfigs
- create a module file to easily swith between this develop version of EB and any others

This is somehow related to this issue https://github.com/hpcugent/easybuild-framework/pull/730.
However, my script clones the git repositories instead of doing a simple installation. So it is easier to do commit, push and pull requests later on, and then contribute to EasyBuild.
