### PR TITLE
Small typo in documentation home page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,7 +80,7 @@ As of version EasyBuild version |version|:
 
 * The complete table of available toolchains is visible at :ref:`toolchains_table`
 * The list of available easyblocks is visible at :ref:`basic_usage_easyblocks`
-* The list of available (generic) easyconfig parameters is visble at :ref:`easyconfigs_parameters`
+* The list of available (generic) easyconfig parameters is visible at :ref:`easyconfigs_parameters`
 
 Appendices
 ==========


### PR DESCRIPTION
Hi guys,

First let me congratulate you for the great job you have done for the EasyBuild Documentation!

I just found a small typo in the home page under the "Lists and tables" section. In the third bullet point there is an "i" missing from the word "visible".

Cheers,
Thekla
