### PR TITLE
mention need to escape % when configuring log file format via configuration file

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,7 @@
 Changelog for EasyBuild documentation
 -------------------------------------
 
+* **release 20150112.01** (`Jan 12th 2014`): mention need to escape ``%`` when configuring log file format via configuration file (see :ref:`logfile_format`)
 * **release 20150107.01** (`Jan 7th 2014`): document behaviour of `dummy` toolchain (:ref:`dummy_toolchain`)
 * **release 20141219.01** (`Dec 19th 2014`): add release notes for EasyBuild v1.16.1
 * **release 20141218.01** (`Dec 18th 2014`): add release notes for EasyBuild v1.16.0

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -409,7 +409,8 @@ is supported:
 * ``%(time)s``: the time at which the installation was started (in ``HHMMSS`` format, e.g. ``214359``)
 
 .. note:: The '``%``' character in these template values must be escaped when used in a configuration file
-          (and only then), e.g., '``%%(name)s``'.
+          (and only then), e.g., '``%%(name)s``'. Without escaping, an error like ``InterpolationMissingOptionError: Bad
+          value substitution`` will be thrown by ``ConfigParser``.
 
 For example, configuring EasyBuild to generate a log file mentioning only the software name in a directory named
 ``easybuild`` can be done via the ``--logfile-format`` command line option::

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -408,12 +408,22 @@ is supported:
 * ``%(date)s``: the date on which the installation was performed (in ``YYYYMMDD`` format, e.g. ``20120324``)
 * ``%(time)s``: the time at which the installation was started (in ``HHMMSS`` format, e.g. ``214359``)
 
-For example, the logfile format can be specified as follows in the
-EasyBuild configuration file:
+.. note:: The '``%``' character in these template values must be escaped when used in a configuration file
+          (and only then), e.g., '``%%(name)s``'.
 
-.. code:: python
+For example, configuring EasyBuild to generate a log file mentioning only the software name in a directory named
+``easybuild`` can be done via the ``--logfile-format`` command line option::
 
-    logfile-format = "easylog", "easybuild-%(name)s.log"
+    eb --logfile-format="easybuild,easybuild-%(name)s.log" ...
+
+or the ``$EASYBUILD_LOGFILE_FORMAT`` environment variable::
+
+    export EASYBUILD_LOGFILE_FORMAT="easybuild,easybuild-%(name)s.log"
+
+or by including the following in an EasyBuild configuration file (note the use of '``%%``' to escape the ``name``
+template value here)::
+
+    logfile-format = "easylog", "easybuild-%%(name)s.log"
 
 
 Optional configuration settings

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -398,7 +398,7 @@ Logfile format (``--logfile-format``)
 *default*:
 ``easybuild, easybuild-%(name)s-%(version)s-%(date)s.%(time)s.log``
 
-The ``logfile-format`` configuration setting contains a tuple
+The `logfile format` configuration setting contains a tuple
 specifying a log directory name and a template log file name.
 In both of these values, using the following string templates
 is supported:
@@ -408,9 +408,10 @@ is supported:
 * ``%(date)s``: the date on which the installation was performed (in ``YYYYMMDD`` format, e.g. ``20120324``)
 * ``%(time)s``: the time at which the installation was started (in ``HHMMSS`` format, e.g. ``214359``)
 
-.. note:: The '``%``' character in these template values must be escaped when used in a configuration file
-          (and only then), e.g., '``%%(name)s``'. Without escaping, an error like ``InterpolationMissingOptionError: Bad
-          value substitution`` will be thrown by ``ConfigParser``.
+.. note:: Because templating is supported in configuration files themselves (see
+          :ref:`configuration_file_templates_constants`), the '``%``' character in these template values must be escaped
+          when used in a configuration file (and only then), e.g., '``%%(name)s``'. Without escaping, an error like
+          ``InterpolationMissingOptionError: Bad value substitution`` will be thrown by ``ConfigParser``.
 
 For example, configuring EasyBuild to generate a log file mentioning only the software name in a directory named
 ``easybuild`` can be done via the ``--logfile-format`` command line option::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ copyright = '2012-2014, Ghent University, CC-BY-SA'
 # The short X.Y version.
 version = '1.16.1'  # this is meant to reference the version of EasyBuild
 # The full version, including alpha/beta/rc tags.
-release = '20150107.01'  # this is meant to reference the version of the documentation itself
+release = '20150112.01'  # this is meant to reference the version of the documentation itself
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
replaces #70 and targets `develop`