### PR TITLE
extend section on (default) EasyBuild configuration files to also cover $XDG_CONFIG_DIRS

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,9 @@
 Changelog for EasyBuild documentation
 -------------------------------------
 
+* **release 20150219.01** (`Feb 19th 2015`): first updates for EasyBuild v2.0.0
+
+  * extend section on (default) EasyBuild configuration files to also cover ``$XDG_CONFIG_DIRS`` (see :ref:`configuration_file:`)
 * **release 20150205.01** (`Feb 5th 2015`): include information on deprecated functionality in (generic) easyblocks (see :ref:`deprecated`)
 * **release 20150126.01** (`Jan 26th 2015`):
 

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -85,9 +85,10 @@ Default configuration files
 +++++++++++++++++++++++++++
 
 By default, EasyBuild will use existing configuration files at the following paths:
- * ``$dir/easybuild.d/*.cfg``, for each directory ``$dir`` listed in ``$XDG_CONFIG_DIRS`` (where ``$XDG_CONFIG_DIRS``
+
+* ``$dir/easybuild.d/*.cfg``, for each directory ``$dir`` listed in ``$XDG_CONFIG_DIRS`` (where ``$XDG_CONFIG_DIRS``
    defaults to ``/etc``)
- * ``$XDG_CONFIG_HOME/easybuild/config.cfg`` (where ``$XDG_CONFIG_HOME`` defaults to ``$HOME/.config``)
+* ``$XDG_CONFIG_HOME/easybuild/config.cfg`` (where ``$XDG_CONFIG_HOME`` defaults to ``$HOME/.config``)
 
 Hence, if ``$XDG_CONFIG_HOME`` and ``$XDG_CONFIG_DIRS`` are not defined, EasyBuild will only consider default
 configuration files at ``/etc/easybuild.d/*.cfg`` and ``$HOME/.config/easybuild/config.cfg``.

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -67,28 +67,50 @@ For more details w.r.t. each of the supported configuration types, see below.
 
 .. _configuration_file:
 
-Configuration file
-~~~~~~~~~~~~~~~~~~
+Configuration file(s)
+~~~~~~~~~~~~~~~~~~~~~
 
 .. _list_of_configuration_files:
 
 List of used configuration files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The set of configuration files that will be used by EasyBuild is
-determined in the following order of preference:
+The set of configuration files that will be used by EasyBuild is determined in the following order of preference:
 
-* the path(s) specified via **command line argument** ``--configfiles``
+* the path(s) specified via the **command line argument** ``--configfiles``
 * the path(s) specified via the ``$EASYBUILD_CONFIGFILES`` **environment variable**
-* the **default path** for the EasyBuild configuration file, i.e.
-   ``$XDG_CONFIG_HOME/easybuild/config.cfg`` (``$XDG_CONFIG_HOME`` defaults to ``$HOME/.config``).
+* the **default paths** for EasyBuild configuration files
 
-Note that each available configuration file will be used, and that the
-configuration settings specified in these files will be retained according to the order of preference as indicated above.
+Default configuration files
++++++++++++++++++++++++++++
 
-On top of this, the command line argument ``--ignoreconfigfiles``
-allows to specify configuration files that should be *ignored* by EasyBuild
-(regardless of whether they are specified via any of the options above).
+By default, EasyBuild will use existing configuration files at the following paths:
+ * ``$dir/easybuild.d/*.cfg``, for each directory ``$dir`` listed in ``$XDG_CONFIG_DIRS`` (where ``$XDG_CONFIG_DIRS``
+   defaults to ``/etc``)
+ * ``$XDG_CONFIG_HOME/easybuild/config.cfg`` (where ``$XDG_CONFIG_HOME`` defaults to ``$HOME/.config``)
+
+Hence, if ``$XDG_CONFIG_HOME`` and ``$XDG_CONFIG_DIRS`` are not defined, EasyBuild will only consider default
+configuration files at ``/etc/easybuild.d/*.cfg`` and ``$HOME/.config/easybuild/config.cfg``.
+
+The configuration file located in ``$XDG_CONFIG_HOME`` will be listed *after* the ones obtained via ``$XDG_CONFIG_DIRS``,
+such that user-defined configuration settings have preference over system defaults.
+
+Multiple configuration files
+++++++++++++++++++++++++++++
+
+If multiple configuration files are listed via a mechanism listed above, the settings in the last
+configuration file have preference over the others.
+
+Each available configuration file will be used, and the configuration settings specified in these files
+will be retained according to the order of preference as indicated above: settings in configuration files specfied via
+``--configfiles`` override those in configuration files specified via ``$EASYBUILD_CONFIGFILES``, which in turns override
+settings in default configuration files.
+
+Ignored configuration files
++++++++++++++++++++++++++++
+
+On top of this, the ``--ignoreconfigfiles`` configuration option allows to specify configuration files that should be
+*ignored* by EasyBuild (regardless of whether they are specified via any of the options above).
 
 
 Configuration file format

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -87,7 +87,7 @@ Default configuration files
 By default, EasyBuild will use existing configuration files at the following paths:
 
 * ``$dir/easybuild.d/*.cfg``, for each directory ``$dir`` listed in ``$XDG_CONFIG_DIRS`` (where ``$XDG_CONFIG_DIRS``
-   defaults to ``/etc``)
+  defaults to ``/etc``)
 * ``$XDG_CONFIG_HOME/easybuild/config.cfg`` (where ``$XDG_CONFIG_HOME`` defaults to ``$HOME/.config``)
 
 Hence, if ``$XDG_CONFIG_HOME`` and ``$XDG_CONFIG_DIRS`` are not defined, EasyBuild will only consider default

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -75,7 +75,7 @@ Configuration file(s)
 List of used configuration files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The set of configuration files that will be used by EasyBuild is determined in the following order of preference:
+The list of configuration files that will be used by EasyBuild is determined in the following order of preference:
 
 * the path(s) specified via the **command line argument** ``--configfiles``
 * the path(s) specified via the ``$EASYBUILD_CONFIGFILES`` **environment variable**

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,9 +41,9 @@ copyright = '2012-2014, Ghent University, CC-BY-SA'
 # other places throughout the built documents.
 #
 # The short X.Y version.
-version = '1.16.1'  # this is meant to reference the version of EasyBuild
+version = '2.0.0'  # this is meant to reference the version of EasyBuild
 # The full version, including alpha/beta/rc tags.
-release = '20150205.01'  # this is meant to reference the version of the documentation itself
+release = '20150219.01'  # this is meant to reference the version of the documentation itself
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
rendered version at https://boegel-eb.readthedocs.org/en/XDG_CONFIG/Configuration.html#configuration-file-s

@JensTimmerman, @fgeorgatos, @wpoely86: please review