### PR TITLE
Script for generating API documentation

### DIFF
--- a/docs/api/easybuild.framework.easyblock.rst
+++ b/docs/api/easybuild.framework.easyblock.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyblock module
+====================================
+
+.. automodule:: easybuild.framework.easyblock
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.constants.rst
+++ b/docs/api/easybuild.framework.easyconfig.constants.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.constants module
+===============================================
+
+.. automodule:: easybuild.framework.easyconfig.constants
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.default.rst
+++ b/docs/api/easybuild.framework.easyconfig.default.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.default module
+=============================================
+
+.. automodule:: easybuild.framework.easyconfig.default
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.easyconfig.rst
+++ b/docs/api/easybuild.framework.easyconfig.easyconfig.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.easyconfig module
+================================================
+
+.. automodule:: easybuild.framework.easyconfig.easyconfig
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.format.convert.rst
+++ b/docs/api/easybuild.framework.easyconfig.format.convert.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.format.convert module
+====================================================
+
+.. automodule:: easybuild.framework.easyconfig.format.convert
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.format.format.rst
+++ b/docs/api/easybuild.framework.easyconfig.format.format.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.format.format module
+===================================================
+
+.. automodule:: easybuild.framework.easyconfig.format.format
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.format.one.rst
+++ b/docs/api/easybuild.framework.easyconfig.format.one.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.format.one module
+================================================
+
+.. automodule:: easybuild.framework.easyconfig.format.one
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.format.pyheaderconfigobj.rst
+++ b/docs/api/easybuild.framework.easyconfig.format.pyheaderconfigobj.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.format.pyheaderconfigobj module
+==============================================================
+
+.. automodule:: easybuild.framework.easyconfig.format.pyheaderconfigobj
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.format.rst
+++ b/docs/api/easybuild.framework.easyconfig.format.rst
@@ -1,0 +1,22 @@
+easybuild.framework.easyconfig.format package
+=============================================
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.framework.easyconfig.format.convert
+   easybuild.framework.easyconfig.format.format
+   easybuild.framework.easyconfig.format.one
+   easybuild.framework.easyconfig.format.pyheaderconfigobj
+   easybuild.framework.easyconfig.format.two
+   easybuild.framework.easyconfig.format.version
+
+Module contents
+---------------
+
+.. automodule:: easybuild.framework.easyconfig.format
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.format.two.rst
+++ b/docs/api/easybuild.framework.easyconfig.format.two.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.format.two module
+================================================
+
+.. automodule:: easybuild.framework.easyconfig.format.two
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.format.version.rst
+++ b/docs/api/easybuild.framework.easyconfig.format.version.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.format.version module
+====================================================
+
+.. automodule:: easybuild.framework.easyconfig.format.version
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.licenses.rst
+++ b/docs/api/easybuild.framework.easyconfig.licenses.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.licenses module
+==============================================
+
+.. automodule:: easybuild.framework.easyconfig.licenses
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.parser.rst
+++ b/docs/api/easybuild.framework.easyconfig.parser.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.parser module
+============================================
+
+.. automodule:: easybuild.framework.easyconfig.parser
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.rst
+++ b/docs/api/easybuild.framework.easyconfig.rst
@@ -1,0 +1,31 @@
+easybuild.framework.easyconfig package
+======================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    easybuild.framework.easyconfig.format
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.framework.easyconfig.constants
+   easybuild.framework.easyconfig.default
+   easybuild.framework.easyconfig.easyconfig
+   easybuild.framework.easyconfig.licenses
+   easybuild.framework.easyconfig.parser
+   easybuild.framework.easyconfig.templates
+   easybuild.framework.easyconfig.tools
+   easybuild.framework.easyconfig.tweak
+
+Module contents
+---------------
+
+.. automodule:: easybuild.framework.easyconfig
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.templates.rst
+++ b/docs/api/easybuild.framework.easyconfig.templates.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.templates module
+===============================================
+
+.. automodule:: easybuild.framework.easyconfig.templates
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.tools.rst
+++ b/docs/api/easybuild.framework.easyconfig.tools.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.tools module
+===========================================
+
+.. automodule:: easybuild.framework.easyconfig.tools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.tweak.rst
+++ b/docs/api/easybuild.framework.easyconfig.tweak.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.tweak module
+===========================================
+
+.. automodule:: easybuild.framework.easyconfig.tweak
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.extension.rst
+++ b/docs/api/easybuild.framework.extension.rst
@@ -1,0 +1,7 @@
+easybuild.framework.extension module
+====================================
+
+.. automodule:: easybuild.framework.extension
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.extensioneasyblock.rst
+++ b/docs/api/easybuild.framework.extensioneasyblock.rst
@@ -1,0 +1,7 @@
+easybuild.framework.extensioneasyblock module
+=============================================
+
+.. automodule:: easybuild.framework.extensioneasyblock
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.rst
+++ b/docs/api/easybuild.framework.rst
@@ -1,0 +1,26 @@
+easybuild.framework package
+===========================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    easybuild.framework.easyconfig
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.framework.easyblock
+   easybuild.framework.extension
+   easybuild.framework.extensioneasyblock
+
+Module contents
+---------------
+
+.. automodule:: easybuild.framework
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.main.rst
+++ b/docs/api/easybuild.main.rst
@@ -1,0 +1,7 @@
+easybuild.main module
+=====================
+
+.. automodule:: easybuild.main
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.rst
+++ b/docs/api/easybuild.rst
@@ -1,0 +1,26 @@
+easybuild package
+=================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    easybuild.framework
+    easybuild.toolchains
+    easybuild.tools
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.main
+
+Module contents
+---------------
+
+.. automodule:: easybuild
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.cgmpich.rst
+++ b/docs/api/easybuild.toolchains.cgmpich.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.cgmpich module
+===================================
+
+.. automodule:: easybuild.toolchains.cgmpich
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.cgmpolf.rst
+++ b/docs/api/easybuild.toolchains.cgmpolf.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.cgmpolf module
+===================================
+
+.. automodule:: easybuild.toolchains.cgmpolf
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.cgmvapich2.rst
+++ b/docs/api/easybuild.toolchains.cgmvapich2.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.cgmvapich2 module
+======================================
+
+.. automodule:: easybuild.toolchains.cgmvapich2
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.cgmvolf.rst
+++ b/docs/api/easybuild.toolchains.cgmvolf.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.cgmvolf module
+===================================
+
+.. automodule:: easybuild.toolchains.cgmvolf
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.cgompi.rst
+++ b/docs/api/easybuild.toolchains.cgompi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.cgompi module
+==================================
+
+.. automodule:: easybuild.toolchains.cgompi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.cgoolf.rst
+++ b/docs/api/easybuild.toolchains.cgoolf.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.cgoolf module
+==================================
+
+.. automodule:: easybuild.toolchains.cgoolf
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.clanggcc.rst
+++ b/docs/api/easybuild.toolchains.clanggcc.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.clanggcc module
+====================================
+
+.. automodule:: easybuild.toolchains.clanggcc
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.compiler.clang.rst
+++ b/docs/api/easybuild.toolchains.compiler.clang.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.compiler.clang module
+==========================================
+
+.. automodule:: easybuild.toolchains.compiler.clang
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.compiler.craype.rst
+++ b/docs/api/easybuild.toolchains.compiler.craype.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.compiler.craype module
+===========================================
+
+.. automodule:: easybuild.toolchains.compiler.craype
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.compiler.cuda.rst
+++ b/docs/api/easybuild.toolchains.compiler.cuda.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.compiler.cuda module
+=========================================
+
+.. automodule:: easybuild.toolchains.compiler.cuda
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.compiler.dummycompiler.rst
+++ b/docs/api/easybuild.toolchains.compiler.dummycompiler.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.compiler.dummycompiler module
+==================================================
+
+.. automodule:: easybuild.toolchains.compiler.dummycompiler
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.compiler.gcc.rst
+++ b/docs/api/easybuild.toolchains.compiler.gcc.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.compiler.gcc module
+========================================
+
+.. automodule:: easybuild.toolchains.compiler.gcc
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.compiler.inteliccifort.rst
+++ b/docs/api/easybuild.toolchains.compiler.inteliccifort.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.compiler.inteliccifort module
+==================================================
+
+.. automodule:: easybuild.toolchains.compiler.inteliccifort
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.compiler.rst
+++ b/docs/api/easybuild.toolchains.compiler.rst
@@ -1,0 +1,22 @@
+easybuild.toolchains.compiler package
+=====================================
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.toolchains.compiler.clang
+   easybuild.toolchains.compiler.craype
+   easybuild.toolchains.compiler.cuda
+   easybuild.toolchains.compiler.dummycompiler
+   easybuild.toolchains.compiler.gcc
+   easybuild.toolchains.compiler.inteliccifort
+
+Module contents
+---------------
+
+.. automodule:: easybuild.toolchains.compiler
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.craycce.rst
+++ b/docs/api/easybuild.toolchains.craycce.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.craycce module
+===================================
+
+.. automodule:: easybuild.toolchains.craycce
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.craygnu.rst
+++ b/docs/api/easybuild.toolchains.craygnu.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.craygnu module
+===================================
+
+.. automodule:: easybuild.toolchains.craygnu
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.crayintel.rst
+++ b/docs/api/easybuild.toolchains.crayintel.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.crayintel module
+=====================================
+
+.. automodule:: easybuild.toolchains.crayintel
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.dummy.rst
+++ b/docs/api/easybuild.toolchains.dummy.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.dummy module
+=================================
+
+.. automodule:: easybuild.toolchains.dummy
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.fft.crayfftw.rst
+++ b/docs/api/easybuild.toolchains.fft.crayfftw.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.fft.crayfftw module
+========================================
+
+.. automodule:: easybuild.toolchains.fft.crayfftw
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.fft.fftw.rst
+++ b/docs/api/easybuild.toolchains.fft.fftw.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.fft.fftw module
+====================================
+
+.. automodule:: easybuild.toolchains.fft.fftw
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.fft.intelfftw.rst
+++ b/docs/api/easybuild.toolchains.fft.intelfftw.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.fft.intelfftw module
+=========================================
+
+.. automodule:: easybuild.toolchains.fft.intelfftw
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.fft.rst
+++ b/docs/api/easybuild.toolchains.fft.rst
@@ -1,0 +1,19 @@
+easybuild.toolchains.fft package
+================================
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.toolchains.fft.crayfftw
+   easybuild.toolchains.fft.fftw
+   easybuild.toolchains.fft.intelfftw
+
+Module contents
+---------------
+
+.. automodule:: easybuild.toolchains.fft
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.foss.rst
+++ b/docs/api/easybuild.toolchains.foss.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.foss module
+================================
+
+.. automodule:: easybuild.toolchains.foss
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gcc.rst
+++ b/docs/api/easybuild.toolchains.gcc.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gcc module
+===============================
+
+.. automodule:: easybuild.toolchains.gcc
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gcccuda.rst
+++ b/docs/api/easybuild.toolchains.gcccuda.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gcccuda module
+===================================
+
+.. automodule:: easybuild.toolchains.gcccuda
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gimkl.rst
+++ b/docs/api/easybuild.toolchains.gimkl.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gimkl module
+=================================
+
+.. automodule:: easybuild.toolchains.gimkl
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gimpi.rst
+++ b/docs/api/easybuild.toolchains.gimpi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gimpi module
+=================================
+
+.. automodule:: easybuild.toolchains.gimpi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gmacml.rst
+++ b/docs/api/easybuild.toolchains.gmacml.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gmacml module
+==================================
+
+.. automodule:: easybuild.toolchains.gmacml
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gmpich.rst
+++ b/docs/api/easybuild.toolchains.gmpich.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gmpich module
+==================================
+
+.. automodule:: easybuild.toolchains.gmpich
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gmpich2.rst
+++ b/docs/api/easybuild.toolchains.gmpich2.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gmpich2 module
+===================================
+
+.. automodule:: easybuild.toolchains.gmpich2
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gmpolf.rst
+++ b/docs/api/easybuild.toolchains.gmpolf.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gmpolf module
+==================================
+
+.. automodule:: easybuild.toolchains.gmpolf
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gmvapich2.rst
+++ b/docs/api/easybuild.toolchains.gmvapich2.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gmvapich2 module
+=====================================
+
+.. automodule:: easybuild.toolchains.gmvapich2
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gmvolf.rst
+++ b/docs/api/easybuild.toolchains.gmvolf.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gmvolf module
+==================================
+
+.. automodule:: easybuild.toolchains.gmvolf
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gnu.rst
+++ b/docs/api/easybuild.toolchains.gnu.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gnu module
+===============================
+
+.. automodule:: easybuild.toolchains.gnu
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.goalf.rst
+++ b/docs/api/easybuild.toolchains.goalf.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.goalf module
+=================================
+
+.. automodule:: easybuild.toolchains.goalf
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gompi.rst
+++ b/docs/api/easybuild.toolchains.gompi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gompi module
+=================================
+
+.. automodule:: easybuild.toolchains.gompi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gompic.rst
+++ b/docs/api/easybuild.toolchains.gompic.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gompic module
+==================================
+
+.. automodule:: easybuild.toolchains.gompic
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.goolf.rst
+++ b/docs/api/easybuild.toolchains.goolf.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.goolf module
+=================================
+
+.. automodule:: easybuild.toolchains.goolf
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.goolfc.rst
+++ b/docs/api/easybuild.toolchains.goolfc.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.goolfc module
+==================================
+
+.. automodule:: easybuild.toolchains.goolfc
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gpsmpi.rst
+++ b/docs/api/easybuild.toolchains.gpsmpi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gpsmpi module
+==================================
+
+.. automodule:: easybuild.toolchains.gpsmpi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gpsolf.rst
+++ b/docs/api/easybuild.toolchains.gpsolf.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gpsolf module
+==================================
+
+.. automodule:: easybuild.toolchains.gpsolf
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.gqacml.rst
+++ b/docs/api/easybuild.toolchains.gqacml.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gqacml module
+==================================
+
+.. automodule:: easybuild.toolchains.gqacml
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.iccifort.rst
+++ b/docs/api/easybuild.toolchains.iccifort.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.iccifort module
+====================================
+
+.. automodule:: easybuild.toolchains.iccifort
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.ictce.rst
+++ b/docs/api/easybuild.toolchains.ictce.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.ictce module
+=================================
+
+.. automodule:: easybuild.toolchains.ictce
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.iimpi.rst
+++ b/docs/api/easybuild.toolchains.iimpi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.iimpi module
+=================================
+
+.. automodule:: easybuild.toolchains.iimpi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.iiqmpi.rst
+++ b/docs/api/easybuild.toolchains.iiqmpi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.iiqmpi module
+==================================
+
+.. automodule:: easybuild.toolchains.iiqmpi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.impich.rst
+++ b/docs/api/easybuild.toolchains.impich.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.impich module
+==================================
+
+.. automodule:: easybuild.toolchains.impich
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.impmkl.rst
+++ b/docs/api/easybuild.toolchains.impmkl.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.impmkl module
+==================================
+
+.. automodule:: easybuild.toolchains.impmkl
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.intel-para.rst
+++ b/docs/api/easybuild.toolchains.intel-para.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.intel-para module
+======================================
+
+.. automodule:: easybuild.toolchains.intel-para
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.intel.rst
+++ b/docs/api/easybuild.toolchains.intel.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.intel module
+=================================
+
+.. automodule:: easybuild.toolchains.intel
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.iomkl.rst
+++ b/docs/api/easybuild.toolchains.iomkl.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.iomkl module
+=================================
+
+.. automodule:: easybuild.toolchains.iomkl
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.iompi.rst
+++ b/docs/api/easybuild.toolchains.iompi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.iompi module
+=================================
+
+.. automodule:: easybuild.toolchains.iompi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.ipsmpi.rst
+++ b/docs/api/easybuild.toolchains.ipsmpi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.ipsmpi module
+==================================
+
+.. automodule:: easybuild.toolchains.ipsmpi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.iqacml.rst
+++ b/docs/api/easybuild.toolchains.iqacml.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.iqacml module
+==================================
+
+.. automodule:: easybuild.toolchains.iqacml
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.ismkl.rst
+++ b/docs/api/easybuild.toolchains.ismkl.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.ismkl module
+=================================
+
+.. automodule:: easybuild.toolchains.ismkl
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.linalg.acml.rst
+++ b/docs/api/easybuild.toolchains.linalg.acml.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.linalg.acml module
+=======================================
+
+.. automodule:: easybuild.toolchains.linalg.acml
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.linalg.atlas.rst
+++ b/docs/api/easybuild.toolchains.linalg.atlas.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.linalg.atlas module
+========================================
+
+.. automodule:: easybuild.toolchains.linalg.atlas
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.linalg.blacs.rst
+++ b/docs/api/easybuild.toolchains.linalg.blacs.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.linalg.blacs module
+========================================
+
+.. automodule:: easybuild.toolchains.linalg.blacs
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.linalg.flame.rst
+++ b/docs/api/easybuild.toolchains.linalg.flame.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.linalg.flame module
+========================================
+
+.. automodule:: easybuild.toolchains.linalg.flame
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.linalg.gotoblas.rst
+++ b/docs/api/easybuild.toolchains.linalg.gotoblas.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.linalg.gotoblas module
+===========================================
+
+.. automodule:: easybuild.toolchains.linalg.gotoblas
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.linalg.intelmkl.rst
+++ b/docs/api/easybuild.toolchains.linalg.intelmkl.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.linalg.intelmkl module
+===========================================
+
+.. automodule:: easybuild.toolchains.linalg.intelmkl
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.linalg.lapack.rst
+++ b/docs/api/easybuild.toolchains.linalg.lapack.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.linalg.lapack module
+=========================================
+
+.. automodule:: easybuild.toolchains.linalg.lapack
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.linalg.libsci.rst
+++ b/docs/api/easybuild.toolchains.linalg.libsci.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.linalg.libsci module
+=========================================
+
+.. automodule:: easybuild.toolchains.linalg.libsci
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.linalg.openblas.rst
+++ b/docs/api/easybuild.toolchains.linalg.openblas.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.linalg.openblas module
+===========================================
+
+.. automodule:: easybuild.toolchains.linalg.openblas
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.linalg.rst
+++ b/docs/api/easybuild.toolchains.linalg.rst
@@ -1,0 +1,26 @@
+easybuild.toolchains.linalg package
+===================================
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.toolchains.linalg.acml
+   easybuild.toolchains.linalg.atlas
+   easybuild.toolchains.linalg.blacs
+   easybuild.toolchains.linalg.flame
+   easybuild.toolchains.linalg.gotoblas
+   easybuild.toolchains.linalg.intelmkl
+   easybuild.toolchains.linalg.lapack
+   easybuild.toolchains.linalg.libsci
+   easybuild.toolchains.linalg.openblas
+   easybuild.toolchains.linalg.scalapack
+
+Module contents
+---------------
+
+.. automodule:: easybuild.toolchains.linalg
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.linalg.scalapack.rst
+++ b/docs/api/easybuild.toolchains.linalg.scalapack.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.linalg.scalapack module
+============================================
+
+.. automodule:: easybuild.toolchains.linalg.scalapack
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.mpi.craympich.rst
+++ b/docs/api/easybuild.toolchains.mpi.craympich.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.mpi.craympich module
+=========================================
+
+.. automodule:: easybuild.toolchains.mpi.craympich
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.mpi.intelmpi.rst
+++ b/docs/api/easybuild.toolchains.mpi.intelmpi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.mpi.intelmpi module
+========================================
+
+.. automodule:: easybuild.toolchains.mpi.intelmpi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.mpi.mpich.rst
+++ b/docs/api/easybuild.toolchains.mpi.mpich.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.mpi.mpich module
+=====================================
+
+.. automodule:: easybuild.toolchains.mpi.mpich
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.mpi.mpich2.rst
+++ b/docs/api/easybuild.toolchains.mpi.mpich2.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.mpi.mpich2 module
+======================================
+
+.. automodule:: easybuild.toolchains.mpi.mpich2
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.mpi.mvapich2.rst
+++ b/docs/api/easybuild.toolchains.mpi.mvapich2.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.mpi.mvapich2 module
+========================================
+
+.. automodule:: easybuild.toolchains.mpi.mvapich2
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.mpi.openmpi.rst
+++ b/docs/api/easybuild.toolchains.mpi.openmpi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.mpi.openmpi module
+=======================================
+
+.. automodule:: easybuild.toolchains.mpi.openmpi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.mpi.qlogicmpi.rst
+++ b/docs/api/easybuild.toolchains.mpi.qlogicmpi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.mpi.qlogicmpi module
+=========================================
+
+.. automodule:: easybuild.toolchains.mpi.qlogicmpi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.mpi.rst
+++ b/docs/api/easybuild.toolchains.mpi.rst
@@ -1,0 +1,23 @@
+easybuild.toolchains.mpi package
+================================
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.toolchains.mpi.craympich
+   easybuild.toolchains.mpi.intelmpi
+   easybuild.toolchains.mpi.mpich
+   easybuild.toolchains.mpi.mpich2
+   easybuild.toolchains.mpi.mvapich2
+   easybuild.toolchains.mpi.openmpi
+   easybuild.toolchains.mpi.qlogicmpi
+
+Module contents
+---------------
+
+.. automodule:: easybuild.toolchains.mpi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.rst
+++ b/docs/api/easybuild.toolchains.rst
@@ -1,0 +1,70 @@
+easybuild.toolchains package
+============================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    easybuild.toolchains.compiler
+    easybuild.toolchains.fft
+    easybuild.toolchains.linalg
+    easybuild.toolchains.mpi
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.toolchains.cgmpich
+   easybuild.toolchains.cgmpolf
+   easybuild.toolchains.cgmvapich2
+   easybuild.toolchains.cgmvolf
+   easybuild.toolchains.cgompi
+   easybuild.toolchains.cgoolf
+   easybuild.toolchains.clanggcc
+   easybuild.toolchains.craycce
+   easybuild.toolchains.craygnu
+   easybuild.toolchains.crayintel
+   easybuild.toolchains.dummy
+   easybuild.toolchains.foss
+   easybuild.toolchains.gcc
+   easybuild.toolchains.gcccuda
+   easybuild.toolchains.gimkl
+   easybuild.toolchains.gimpi
+   easybuild.toolchains.gmacml
+   easybuild.toolchains.gmpich
+   easybuild.toolchains.gmpich2
+   easybuild.toolchains.gmpolf
+   easybuild.toolchains.gmvapich2
+   easybuild.toolchains.gmvolf
+   easybuild.toolchains.gnu
+   easybuild.toolchains.goalf
+   easybuild.toolchains.gompi
+   easybuild.toolchains.gompic
+   easybuild.toolchains.goolf
+   easybuild.toolchains.goolfc
+   easybuild.toolchains.gpsmpi
+   easybuild.toolchains.gpsolf
+   easybuild.toolchains.gqacml
+   easybuild.toolchains.iccifort
+   easybuild.toolchains.ictce
+   easybuild.toolchains.iimpi
+   easybuild.toolchains.iiqmpi
+   easybuild.toolchains.impich
+   easybuild.toolchains.impmkl
+   easybuild.toolchains.intel-para
+   easybuild.toolchains.intel
+   easybuild.toolchains.iomkl
+   easybuild.toolchains.iompi
+   easybuild.toolchains.ipsmpi
+   easybuild.toolchains.iqacml
+   easybuild.toolchains.ismkl
+
+Module contents
+---------------
+
+.. automodule:: easybuild.toolchains
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.asyncprocess.rst
+++ b/docs/api/easybuild.tools.asyncprocess.rst
@@ -1,0 +1,7 @@
+easybuild.tools.asyncprocess module
+===================================
+
+.. automodule:: easybuild.tools.asyncprocess
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.build_details.rst
+++ b/docs/api/easybuild.tools.build_details.rst
@@ -1,0 +1,7 @@
+easybuild.tools.build_details module
+====================================
+
+.. automodule:: easybuild.tools.build_details
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.build_log.rst
+++ b/docs/api/easybuild.tools.build_log.rst
@@ -1,0 +1,7 @@
+easybuild.tools.build_log module
+================================
+
+.. automodule:: easybuild.tools.build_log
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.config.rst
+++ b/docs/api/easybuild.tools.config.rst
@@ -1,0 +1,7 @@
+easybuild.tools.config module
+=============================
+
+.. automodule:: easybuild.tools.config
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.configobj.rst
+++ b/docs/api/easybuild.tools.configobj.rst
@@ -1,0 +1,7 @@
+easybuild.tools.configobj module
+================================
+
+.. automodule:: easybuild.tools.configobj
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.convert.rst
+++ b/docs/api/easybuild.tools.convert.rst
@@ -1,0 +1,7 @@
+easybuild.tools.convert module
+==============================
+
+.. automodule:: easybuild.tools.convert
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.deprecated.rst
+++ b/docs/api/easybuild.tools.deprecated.rst
@@ -1,0 +1,10 @@
+easybuild.tools.deprecated package
+==================================
+
+Module contents
+---------------
+
+.. automodule:: easybuild.tools.deprecated
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.docs.rst
+++ b/docs/api/easybuild.tools.docs.rst
@@ -1,0 +1,7 @@
+easybuild.tools.docs module
+===========================
+
+.. automodule:: easybuild.tools.docs
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.environment.rst
+++ b/docs/api/easybuild.tools.environment.rst
@@ -1,0 +1,7 @@
+easybuild.tools.environment module
+==================================
+
+.. automodule:: easybuild.tools.environment
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.filetools.rst
+++ b/docs/api/easybuild.tools.filetools.rst
@@ -1,0 +1,7 @@
+easybuild.tools.filetools module
+================================
+
+.. automodule:: easybuild.tools.filetools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.github.rst
+++ b/docs/api/easybuild.tools.github.rst
@@ -1,0 +1,7 @@
+easybuild.tools.github module
+=============================
+
+.. automodule:: easybuild.tools.github
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.include.rst
+++ b/docs/api/easybuild.tools.include.rst
@@ -1,0 +1,7 @@
+easybuild.tools.include module
+==============================
+
+.. automodule:: easybuild.tools.include
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.jenkins.rst
+++ b/docs/api/easybuild.tools.jenkins.rst
@@ -1,0 +1,7 @@
+easybuild.tools.jenkins module
+==============================
+
+.. automodule:: easybuild.tools.jenkins
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.job.backend.rst
+++ b/docs/api/easybuild.tools.job.backend.rst
@@ -1,0 +1,7 @@
+easybuild.tools.job.backend module
+==================================
+
+.. automodule:: easybuild.tools.job.backend
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.job.gc3pie.rst
+++ b/docs/api/easybuild.tools.job.gc3pie.rst
@@ -1,0 +1,7 @@
+easybuild.tools.job.gc3pie module
+=================================
+
+.. automodule:: easybuild.tools.job.gc3pie
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.job.pbs_python.rst
+++ b/docs/api/easybuild.tools.job.pbs_python.rst
@@ -1,0 +1,7 @@
+easybuild.tools.job.pbs_python module
+=====================================
+
+.. automodule:: easybuild.tools.job.pbs_python
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.job.rst
+++ b/docs/api/easybuild.tools.job.rst
@@ -1,0 +1,19 @@
+easybuild.tools.job package
+===========================
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.tools.job.backend
+   easybuild.tools.job.gc3pie
+   easybuild.tools.job.pbs_python
+
+Module contents
+---------------
+
+.. automodule:: easybuild.tools.job
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.module_generator.rst
+++ b/docs/api/easybuild.tools.module_generator.rst
@@ -1,0 +1,7 @@
+easybuild.tools.module_generator module
+=======================================
+
+.. automodule:: easybuild.tools.module_generator
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.module_naming_scheme.categorized_hmns.rst
+++ b/docs/api/easybuild.tools.module_naming_scheme.categorized_hmns.rst
@@ -1,0 +1,7 @@
+easybuild.tools.module_naming_scheme.categorized_hmns module
+============================================================
+
+.. automodule:: easybuild.tools.module_naming_scheme.categorized_hmns
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.module_naming_scheme.easybuild_mns.rst
+++ b/docs/api/easybuild.tools.module_naming_scheme.easybuild_mns.rst
@@ -1,0 +1,7 @@
+easybuild.tools.module_naming_scheme.easybuild_mns module
+=========================================================
+
+.. automodule:: easybuild.tools.module_naming_scheme.easybuild_mns
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.module_naming_scheme.hierarchical_mns.rst
+++ b/docs/api/easybuild.tools.module_naming_scheme.hierarchical_mns.rst
@@ -1,0 +1,7 @@
+easybuild.tools.module_naming_scheme.hierarchical_mns module
+============================================================
+
+.. automodule:: easybuild.tools.module_naming_scheme.hierarchical_mns
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.module_naming_scheme.migrate_from_eb_to_hmns.rst
+++ b/docs/api/easybuild.tools.module_naming_scheme.migrate_from_eb_to_hmns.rst
@@ -1,0 +1,7 @@
+easybuild.tools.module_naming_scheme.migrate_from_eb_to_hmns module
+===================================================================
+
+.. automodule:: easybuild.tools.module_naming_scheme.migrate_from_eb_to_hmns
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.module_naming_scheme.mns.rst
+++ b/docs/api/easybuild.tools.module_naming_scheme.mns.rst
@@ -1,0 +1,7 @@
+easybuild.tools.module_naming_scheme.mns module
+===============================================
+
+.. automodule:: easybuild.tools.module_naming_scheme.mns
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.module_naming_scheme.rst
+++ b/docs/api/easybuild.tools.module_naming_scheme.rst
@@ -1,0 +1,23 @@
+easybuild.tools.module_naming_scheme package
+============================================
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.tools.module_naming_scheme.categorized_hmns
+   easybuild.tools.module_naming_scheme.easybuild_mns
+   easybuild.tools.module_naming_scheme.hierarchical_mns
+   easybuild.tools.module_naming_scheme.migrate_from_eb_to_hmns
+   easybuild.tools.module_naming_scheme.mns
+   easybuild.tools.module_naming_scheme.toolchain
+   easybuild.tools.module_naming_scheme.utilities
+
+Module contents
+---------------
+
+.. automodule:: easybuild.tools.module_naming_scheme
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.module_naming_scheme.toolchain.rst
+++ b/docs/api/easybuild.tools.module_naming_scheme.toolchain.rst
@@ -1,0 +1,7 @@
+easybuild.tools.module_naming_scheme.toolchain module
+=====================================================
+
+.. automodule:: easybuild.tools.module_naming_scheme.toolchain
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.module_naming_scheme.utilities.rst
+++ b/docs/api/easybuild.tools.module_naming_scheme.utilities.rst
@@ -1,0 +1,7 @@
+easybuild.tools.module_naming_scheme.utilities module
+=====================================================
+
+.. automodule:: easybuild.tools.module_naming_scheme.utilities
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.modules.rst
+++ b/docs/api/easybuild.tools.modules.rst
@@ -1,0 +1,7 @@
+easybuild.tools.modules module
+==============================
+
+.. automodule:: easybuild.tools.modules
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.options.rst
+++ b/docs/api/easybuild.tools.options.rst
@@ -1,0 +1,7 @@
+easybuild.tools.options module
+==============================
+
+.. automodule:: easybuild.tools.options
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.ordereddict.rst
+++ b/docs/api/easybuild.tools.ordereddict.rst
@@ -1,0 +1,7 @@
+easybuild.tools.ordereddict module
+==================================
+
+.. automodule:: easybuild.tools.ordereddict
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.package.package_naming_scheme.easybuild_pns.rst
+++ b/docs/api/easybuild.tools.package.package_naming_scheme.easybuild_pns.rst
@@ -1,0 +1,7 @@
+easybuild.tools.package.package_naming_scheme.easybuild_pns module
+==================================================================
+
+.. automodule:: easybuild.tools.package.package_naming_scheme.easybuild_pns
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.package.package_naming_scheme.pns.rst
+++ b/docs/api/easybuild.tools.package.package_naming_scheme.pns.rst
@@ -1,0 +1,7 @@
+easybuild.tools.package.package_naming_scheme.pns module
+========================================================
+
+.. automodule:: easybuild.tools.package.package_naming_scheme.pns
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.package.package_naming_scheme.rst
+++ b/docs/api/easybuild.tools.package.package_naming_scheme.rst
@@ -1,0 +1,18 @@
+easybuild.tools.package.package_naming_scheme package
+=====================================================
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.tools.package.package_naming_scheme.easybuild_pns
+   easybuild.tools.package.package_naming_scheme.pns
+
+Module contents
+---------------
+
+.. automodule:: easybuild.tools.package.package_naming_scheme
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.package.rst
+++ b/docs/api/easybuild.tools.package.rst
@@ -1,0 +1,24 @@
+easybuild.tools.package package
+===============================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    easybuild.tools.package.package_naming_scheme
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.tools.package.utilities
+
+Module contents
+---------------
+
+.. automodule:: easybuild.tools.package
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.package.utilities.rst
+++ b/docs/api/easybuild.tools.package.utilities.rst
@@ -1,0 +1,7 @@
+easybuild.tools.package.utilities module
+========================================
+
+.. automodule:: easybuild.tools.package.utilities
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.parallelbuild.rst
+++ b/docs/api/easybuild.tools.parallelbuild.rst
@@ -1,0 +1,7 @@
+easybuild.tools.parallelbuild module
+====================================
+
+.. automodule:: easybuild.tools.parallelbuild
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.repository.filerepo.rst
+++ b/docs/api/easybuild.tools.repository.filerepo.rst
@@ -1,0 +1,7 @@
+easybuild.tools.repository.filerepo module
+==========================================
+
+.. automodule:: easybuild.tools.repository.filerepo
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.repository.gitrepo.rst
+++ b/docs/api/easybuild.tools.repository.gitrepo.rst
@@ -1,0 +1,7 @@
+easybuild.tools.repository.gitrepo module
+=========================================
+
+.. automodule:: easybuild.tools.repository.gitrepo
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.repository.repository.rst
+++ b/docs/api/easybuild.tools.repository.repository.rst
@@ -1,0 +1,7 @@
+easybuild.tools.repository.repository module
+============================================
+
+.. automodule:: easybuild.tools.repository.repository
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.repository.rst
+++ b/docs/api/easybuild.tools.repository.rst
@@ -1,0 +1,20 @@
+easybuild.tools.repository package
+==================================
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.tools.repository.filerepo
+   easybuild.tools.repository.gitrepo
+   easybuild.tools.repository.repository
+   easybuild.tools.repository.svnrepo
+
+Module contents
+---------------
+
+.. automodule:: easybuild.tools.repository
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.repository.svnrepo.rst
+++ b/docs/api/easybuild.tools.repository.svnrepo.rst
@@ -1,0 +1,7 @@
+easybuild.tools.repository.svnrepo module
+=========================================
+
+.. automodule:: easybuild.tools.repository.svnrepo
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.robot.rst
+++ b/docs/api/easybuild.tools.robot.rst
@@ -1,0 +1,7 @@
+easybuild.tools.robot module
+============================
+
+.. automodule:: easybuild.tools.robot
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.rst
+++ b/docs/api/easybuild.tools.rst
@@ -1,0 +1,52 @@
+easybuild.tools package
+=======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    easybuild.tools.deprecated
+    easybuild.tools.job
+    easybuild.tools.module_naming_scheme
+    easybuild.tools.package
+    easybuild.tools.repository
+    easybuild.tools.toolchain
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.tools.asyncprocess
+   easybuild.tools.build_details
+   easybuild.tools.build_log
+   easybuild.tools.config
+   easybuild.tools.configobj
+   easybuild.tools.convert
+   easybuild.tools.docs
+   easybuild.tools.environment
+   easybuild.tools.filetools
+   easybuild.tools.github
+   easybuild.tools.include
+   easybuild.tools.jenkins
+   easybuild.tools.module_generator
+   easybuild.tools.modules
+   easybuild.tools.options
+   easybuild.tools.ordereddict
+   easybuild.tools.parallelbuild
+   easybuild.tools.robot
+   easybuild.tools.run
+   easybuild.tools.systemtools
+   easybuild.tools.testing
+   easybuild.tools.utilities
+   easybuild.tools.variables
+   easybuild.tools.version
+
+Module contents
+---------------
+
+.. automodule:: easybuild.tools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.run.rst
+++ b/docs/api/easybuild.tools.run.rst
@@ -1,0 +1,7 @@
+easybuild.tools.run module
+==========================
+
+.. automodule:: easybuild.tools.run
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.systemtools.rst
+++ b/docs/api/easybuild.tools.systemtools.rst
@@ -1,0 +1,7 @@
+easybuild.tools.systemtools module
+==================================
+
+.. automodule:: easybuild.tools.systemtools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.testing.rst
+++ b/docs/api/easybuild.tools.testing.rst
@@ -1,0 +1,7 @@
+easybuild.tools.testing module
+==============================
+
+.. automodule:: easybuild.tools.testing
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.toolchain.compiler.rst
+++ b/docs/api/easybuild.tools.toolchain.compiler.rst
@@ -1,0 +1,7 @@
+easybuild.tools.toolchain.compiler module
+=========================================
+
+.. automodule:: easybuild.tools.toolchain.compiler
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.toolchain.constants.rst
+++ b/docs/api/easybuild.tools.toolchain.constants.rst
@@ -1,0 +1,7 @@
+easybuild.tools.toolchain.constants module
+==========================================
+
+.. automodule:: easybuild.tools.toolchain.constants
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.toolchain.fft.rst
+++ b/docs/api/easybuild.tools.toolchain.fft.rst
@@ -1,0 +1,7 @@
+easybuild.tools.toolchain.fft module
+====================================
+
+.. automodule:: easybuild.tools.toolchain.fft
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.toolchain.linalg.rst
+++ b/docs/api/easybuild.tools.toolchain.linalg.rst
@@ -1,0 +1,7 @@
+easybuild.tools.toolchain.linalg module
+=======================================
+
+.. automodule:: easybuild.tools.toolchain.linalg
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.toolchain.mpi.rst
+++ b/docs/api/easybuild.tools.toolchain.mpi.rst
@@ -1,0 +1,7 @@
+easybuild.tools.toolchain.mpi module
+====================================
+
+.. automodule:: easybuild.tools.toolchain.mpi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.toolchain.options.rst
+++ b/docs/api/easybuild.tools.toolchain.options.rst
@@ -1,0 +1,7 @@
+easybuild.tools.toolchain.options module
+========================================
+
+.. automodule:: easybuild.tools.toolchain.options
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.toolchain.rst
+++ b/docs/api/easybuild.tools.toolchain.rst
@@ -1,0 +1,26 @@
+easybuild.tools.toolchain package
+=================================
+
+Submodules
+----------
+
+.. toctree::
+
+   easybuild.tools.toolchain.compiler
+   easybuild.tools.toolchain.constants
+   easybuild.tools.toolchain.fft
+   easybuild.tools.toolchain.linalg
+   easybuild.tools.toolchain.mpi
+   easybuild.tools.toolchain.options
+   easybuild.tools.toolchain.toolchain
+   easybuild.tools.toolchain.toolchainvariables
+   easybuild.tools.toolchain.utilities
+   easybuild.tools.toolchain.variables
+
+Module contents
+---------------
+
+.. automodule:: easybuild.tools.toolchain
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.toolchain.toolchain.rst
+++ b/docs/api/easybuild.tools.toolchain.toolchain.rst
@@ -1,0 +1,7 @@
+easybuild.tools.toolchain.toolchain module
+==========================================
+
+.. automodule:: easybuild.tools.toolchain.toolchain
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.toolchain.toolchainvariables.rst
+++ b/docs/api/easybuild.tools.toolchain.toolchainvariables.rst
@@ -1,0 +1,7 @@
+easybuild.tools.toolchain.toolchainvariables module
+===================================================
+
+.. automodule:: easybuild.tools.toolchain.toolchainvariables
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.toolchain.utilities.rst
+++ b/docs/api/easybuild.tools.toolchain.utilities.rst
@@ -1,0 +1,7 @@
+easybuild.tools.toolchain.utilities module
+==========================================
+
+.. automodule:: easybuild.tools.toolchain.utilities
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.toolchain.variables.rst
+++ b/docs/api/easybuild.tools.toolchain.variables.rst
@@ -1,0 +1,7 @@
+easybuild.tools.toolchain.variables module
+==========================================
+
+.. automodule:: easybuild.tools.toolchain.variables
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.utilities.rst
+++ b/docs/api/easybuild.tools.utilities.rst
@@ -1,0 +1,7 @@
+easybuild.tools.utilities module
+================================
+
+.. automodule:: easybuild.tools.utilities
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.variables.rst
+++ b/docs/api/easybuild.tools.variables.rst
@@ -1,0 +1,7 @@
+easybuild.tools.variables module
+================================
+
+.. automodule:: easybuild.tools.variables
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.version.rst
+++ b/docs/api/easybuild.tools.version.rst
@@ -1,0 +1,7 @@
+easybuild.tools.version module
+==============================
+
+.. automodule:: easybuild.tools.version
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,0 +1,9 @@
+easybuild-framework
+===================
+
+.. toctree::
+   :maxdepth: 4
+
+   easybuild
+   setup
+   test

--- a/docs/api/setup.rst
+++ b/docs/api/setup.rst
@@ -1,0 +1,7 @@
+setup module
+============
+
+.. automodule:: setup
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.asyncprocess.rst
+++ b/docs/api/test.framework.asyncprocess.rst
@@ -1,0 +1,7 @@
+test.framework.asyncprocess module
+==================================
+
+.. automodule:: test.framework.asyncprocess
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.build_log.rst
+++ b/docs/api/test.framework.build_log.rst
@@ -1,0 +1,7 @@
+test.framework.build_log module
+===============================
+
+.. automodule:: test.framework.build_log
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.config.rst
+++ b/docs/api/test.framework.config.rst
@@ -1,0 +1,7 @@
+test.framework.config module
+============================
+
+.. automodule:: test.framework.config
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.docs.rst
+++ b/docs/api/test.framework.docs.rst
@@ -1,0 +1,7 @@
+test.framework.docs module
+==========================
+
+.. automodule:: test.framework.docs
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.easyblock.rst
+++ b/docs/api/test.framework.easyblock.rst
@@ -1,0 +1,7 @@
+test.framework.easyblock module
+===============================
+
+.. automodule:: test.framework.easyblock
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.easyconfig.rst
+++ b/docs/api/test.framework.easyconfig.rst
@@ -1,0 +1,7 @@
+test.framework.easyconfig module
+================================
+
+.. automodule:: test.framework.easyconfig
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.easyconfigformat.rst
+++ b/docs/api/test.framework.easyconfigformat.rst
@@ -1,0 +1,7 @@
+test.framework.easyconfigformat module
+======================================
+
+.. automodule:: test.framework.easyconfigformat
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.easyconfigparser.rst
+++ b/docs/api/test.framework.easyconfigparser.rst
@@ -1,0 +1,7 @@
+test.framework.easyconfigparser module
+======================================
+
+.. automodule:: test.framework.easyconfigparser
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.easyconfigversion.rst
+++ b/docs/api/test.framework.easyconfigversion.rst
@@ -1,0 +1,7 @@
+test.framework.easyconfigversion module
+=======================================
+
+.. automodule:: test.framework.easyconfigversion
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.ebconfigobj.rst
+++ b/docs/api/test.framework.ebconfigobj.rst
@@ -1,0 +1,7 @@
+test.framework.ebconfigobj module
+=================================
+
+.. automodule:: test.framework.ebconfigobj
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.filetools.rst
+++ b/docs/api/test.framework.filetools.rst
@@ -1,0 +1,7 @@
+test.framework.filetools module
+===============================
+
+.. automodule:: test.framework.filetools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.format_convert.rst
+++ b/docs/api/test.framework.format_convert.rst
@@ -1,0 +1,7 @@
+test.framework.format_convert module
+====================================
+
+.. automodule:: test.framework.format_convert
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.general.rst
+++ b/docs/api/test.framework.general.rst
@@ -1,0 +1,7 @@
+test.framework.general module
+=============================
+
+.. automodule:: test.framework.general
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.github.rst
+++ b/docs/api/test.framework.github.rst
@@ -1,0 +1,7 @@
+test.framework.github module
+============================
+
+.. automodule:: test.framework.github
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.include.rst
+++ b/docs/api/test.framework.include.rst
@@ -1,0 +1,7 @@
+test.framework.include module
+=============================
+
+.. automodule:: test.framework.include
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.license.rst
+++ b/docs/api/test.framework.license.rst
@@ -1,0 +1,7 @@
+test.framework.license module
+=============================
+
+.. automodule:: test.framework.license
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.module_generator.rst
+++ b/docs/api/test.framework.module_generator.rst
@@ -1,0 +1,7 @@
+test.framework.module_generator module
+======================================
+
+.. automodule:: test.framework.module_generator
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.modules.rst
+++ b/docs/api/test.framework.modules.rst
@@ -1,0 +1,7 @@
+test.framework.modules module
+=============================
+
+.. automodule:: test.framework.modules
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.modulestool.rst
+++ b/docs/api/test.framework.modulestool.rst
@@ -1,0 +1,7 @@
+test.framework.modulestool module
+=================================
+
+.. automodule:: test.framework.modulestool
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.options.rst
+++ b/docs/api/test.framework.options.rst
@@ -1,0 +1,7 @@
+test.framework.options module
+=============================
+
+.. automodule:: test.framework.options
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.package.rst
+++ b/docs/api/test.framework.package.rst
@@ -1,0 +1,7 @@
+test.framework.package module
+=============================
+
+.. automodule:: test.framework.package
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.parallelbuild.rst
+++ b/docs/api/test.framework.parallelbuild.rst
@@ -1,0 +1,7 @@
+test.framework.parallelbuild module
+===================================
+
+.. automodule:: test.framework.parallelbuild
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.repository.rst
+++ b/docs/api/test.framework.repository.rst
@@ -1,0 +1,7 @@
+test.framework.repository module
+================================
+
+.. automodule:: test.framework.repository
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.robot.rst
+++ b/docs/api/test.framework.robot.rst
@@ -1,0 +1,7 @@
+test.framework.robot module
+===========================
+
+.. automodule:: test.framework.robot
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.rst
+++ b/docs/api/test.framework.rst
@@ -1,0 +1,50 @@
+test.framework package
+======================
+
+Submodules
+----------
+
+.. toctree::
+
+   test.framework.asyncprocess
+   test.framework.build_log
+   test.framework.config
+   test.framework.docs
+   test.framework.easyblock
+   test.framework.easyconfig
+   test.framework.easyconfigformat
+   test.framework.easyconfigparser
+   test.framework.easyconfigversion
+   test.framework.ebconfigobj
+   test.framework.filetools
+   test.framework.format_convert
+   test.framework.general
+   test.framework.github
+   test.framework.include
+   test.framework.license
+   test.framework.module_generator
+   test.framework.modules
+   test.framework.modulestool
+   test.framework.options
+   test.framework.package
+   test.framework.parallelbuild
+   test.framework.repository
+   test.framework.robot
+   test.framework.run
+   test.framework.scripts
+   test.framework.suite
+   test.framework.systemtools
+   test.framework.toolchain
+   test.framework.toolchainvariables
+   test.framework.toy_build
+   test.framework.tweak
+   test.framework.utilities
+   test.framework.variables
+
+Module contents
+---------------
+
+.. automodule:: test.framework
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.run.rst
+++ b/docs/api/test.framework.run.rst
@@ -1,0 +1,7 @@
+test.framework.run module
+=========================
+
+.. automodule:: test.framework.run
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.scripts.rst
+++ b/docs/api/test.framework.scripts.rst
@@ -1,0 +1,7 @@
+test.framework.scripts module
+=============================
+
+.. automodule:: test.framework.scripts
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.suite.rst
+++ b/docs/api/test.framework.suite.rst
@@ -1,0 +1,7 @@
+test.framework.suite module
+===========================
+
+.. automodule:: test.framework.suite
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.systemtools.rst
+++ b/docs/api/test.framework.systemtools.rst
@@ -1,0 +1,7 @@
+test.framework.systemtools module
+=================================
+
+.. automodule:: test.framework.systemtools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.toolchain.rst
+++ b/docs/api/test.framework.toolchain.rst
@@ -1,0 +1,7 @@
+test.framework.toolchain module
+===============================
+
+.. automodule:: test.framework.toolchain
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.toolchainvariables.rst
+++ b/docs/api/test.framework.toolchainvariables.rst
@@ -1,0 +1,7 @@
+test.framework.toolchainvariables module
+========================================
+
+.. automodule:: test.framework.toolchainvariables
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.toy_build.rst
+++ b/docs/api/test.framework.toy_build.rst
@@ -1,0 +1,7 @@
+test.framework.toy_build module
+===============================
+
+.. automodule:: test.framework.toy_build
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.tweak.rst
+++ b/docs/api/test.framework.tweak.rst
@@ -1,0 +1,7 @@
+test.framework.tweak module
+===========================
+
+.. automodule:: test.framework.tweak
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.utilities.rst
+++ b/docs/api/test.framework.utilities.rst
@@ -1,0 +1,7 @@
+test.framework.utilities module
+===============================
+
+.. automodule:: test.framework.utilities
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.framework.variables.rst
+++ b/docs/api/test.framework.variables.rst
@@ -1,0 +1,7 @@
+test.framework.variables module
+===============================
+
+.. automodule:: test.framework.variables
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/test.rst
+++ b/docs/api/test.rst
@@ -1,0 +1,17 @@
+test package
+============
+
+Subpackages
+-----------
+
+.. toctree::
+
+    test.framework
+
+Module contents
+---------------
+
+.. automodule:: test
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/scripts/generate_api.py
+++ b/docs/scripts/generate_api.py
@@ -31,9 +31,18 @@ This script requires Sphinx to be installed (http://sphinx-doc.org/index.html).
 
 import subprocess
 
+from vsc.utils.generaloption import simple_option
+
+
+options = {
+    'out_folder': ('Path to folder where api docfiles will be written', 'string', 'store', 'api', 'o'),
+    'module': ('Path to module for which api docs will be generated', 'string', 'store', '', 'm')
+}
+so = simple_option(options)
+
 # calls sphinx's automatic apidoc generator
 # -o specifies the output folder
 # -f forces to overwrite existing files
 # -e specifies that every module is written in a separate file
-subprocess.call("sphinx-apidoc -o 'api' '../../../easybuild-framework/' -f -e", shell=True)
+subprocess.call("sphinx-apidoc -o" + so.options.out_folder + " " + so.options.module + " -f -e", shell=True)
 

--- a/docs/scripts/generate_api.py
+++ b/docs/scripts/generate_api.py
@@ -1,0 +1,39 @@
+# #
+# Copyright 2015-2015 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+# #
+"""
+Generates API documentation for readthedocs (rst format)
+This script requires Sphinx to be installed (http://sphinx-doc.org/index.html).
+
+@author Caroline De Brouwer (Ghent University)
+"""
+
+import subprocess
+
+# calls sphinx's automatic apidoc generator
+# -o specifies the output folder
+# -f forces to overwrite existing files
+# -e specifies that every module is written in a separate file
+subprocess.call("sphinx-apidoc -o 'api' '../../../easybuild-framework/' -f -e", shell=True)
+


### PR DESCRIPTION
Also includes the generated docs

For prettifying, some things in the docstrings will have to be changed, e.g @param and @author tags

For author tags, use field lists (`:author: Name`, see http://sphinx-doc.org/markup/misc.html#file-wide-metadata)

See also: http://sphinx-doc.org/domains.html#the-python-domain (especially the "into fields list" section)