### PR TITLE
add documentation on deprecated functions provided by easyblocks

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,7 @@
 Changelog for EasyBuild documentation
 -------------------------------------
 
+* **release 20161014.01** (`Oct 14th 2016`): update documentation on deprecated functionality (see :ref:`deprecated`)
 * **release 20161010.01** (`Oct 10th 2016`): add page for EasyBuild demos (see :ref:`demos`)
 * **release 20160923.02** (`Sept 23rd 2016`): update release notes for EasyBuild v2.9.0 (see :ref:`release_notes_eb290`)
 * **release 20160923.01** (`Sept 23rd 2016`): add generated list of supported software (see :ref:`list_software`)

--- a/docs/Deprecated-functionality.rst
+++ b/docs/Deprecated-functionality.rst
@@ -35,6 +35,8 @@ For authors of easyconfig files:
 For developers of easyblocks:
 
 * :ref:`depr_error_reporting`
+* :ref:`depr_lapack_get_blas_lib`
+* :ref:`depr_get_netcdf_module_set_cmds`
 
 For EasyBuild framework developers:
 
@@ -71,6 +73,48 @@ To report errors, an ``EasyBuildError`` should be raised instead. For example:
     # make sure config.sh script is there
     if not os.path.exists(os.path.join(self.builddir, 'config.sh')):
         raise EasyBuildError("config.sh script is missing in %s", self.builddir)
+
+.. _depr_lapack_get_blas_lib:
+
+``get_blas_lib`` function provided by ``LAPACK`` easyblock will be removed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Use of the** ``get_blas_lib`` **function provided by the** ``LAPACK`` **easyblock is deprecated.**
+
+* *deprecated since:* EasyBuild v1.3.0 (April'13); see https://github.com/hpcugent/easybuild-easyblocks/pull/150
+* *removed in:* EasyBuild v3.0
+* *alternative(s)*: **leverage modules from** ``easybuild.toolchain.linalg``
+
+The ``get_blas_lib`` function provided by the ``LAPACK`` easyblock will be removed, mainly because it includes
+a hardcoded list of BLAS libraries.
+
+It should be replaced by 'inlining' similar code into the easyblocks that rely on it
+(e.g. ScaLAPACK, cfr. https://github.com/hpcugent/easybuild-easyblocks/pull/1014), which only refers
+to the BLAS libraries that are relevant in that context.
+
+
+.. _depr_get_netcdf_module_set_cmds:
+
+``get_netcdf_module_set_cmds`` function provided by ``netCDF`` easyblock will be removed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Use of the** ``get_netcdf_module_set_cmds`` **function provided by the** ``netCDF`` **easyblock is deprecated.**
+
+* *deprecated since:* EasyBuild v2.1.0 (April'15); see https://github.com/hpcugent/easybuild-easyblocks/pull/590
+* *removed in:* EasyBuild v3.0
+* *alternative(s)*: **rely on** ``set_netcdf_env_vars`` **and use** ``self.module_generator.set_environment``
+
+The ``get_netcdf_module_set_cmds`` function provided by the ``netCDF`` easyblock will be removed, because it
+returns ``setenv`` statements to be included in module files that are only compatible with module files in Tcl syntax;
+i.e. it does not take into account the ``--module-syntax`` configuration option.
+
+The use of ```` should be replaced by using ``set_netcdf_env_vars`` to define the ``NETCDF*`` environment variables,
+in combination with ``self.module_generator.set_environment`` to obtain ``setenv`` statements that are compatible
+with the module syntax (``Tcl`` or ``Lua``) being used.
+
+See for example the changes made to the ``WRF`` and ``WPS``
+easyblocks in https://github.com/hpcugent/easybuild-easyblocks/commit/7a05cbd823769e343b951002b4735dc7632e19c0.
+
 
 .. _deprecation_policy:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ copyright = '2012-2016, Ghent University, CC-BY-SA'
 # The short X.Y version.
 version = '2.9.0'  # this is meant to reference the version of EasyBuild
 # The full version, including alpha/beta/rc tags.
-release = '20161010.01'  # this is meant to reference the version of the documentation itself
+release = '20161014.01'  # this is meant to reference the version of the documentation itself
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
see http://boegel-eb.readthedocs.io/en/deprecated_easyblock_functions/Deprecated-functionality.html#depr-lapack-get-blas-lib