### PR TITLE
document specifying of checksums + alternate (& deprecated) format for sources

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -5,6 +5,7 @@ Changelog for EasyBuild documentation
 
 (for EasyBuild release notes, see :ref:`release_notes`)
 
+* **release 20170623.01** (`June 23rd 2017`): document use of ``checksums`` & alternative formats for ``sources`` (see :ref:`common_easyconfig_param_sources`)
 * **release 20170622.01** (`June 22nd 2017`): document support for detecting loaded modules (see :ref:`detect_loaded_modules`)
 * **release 20170522.01** (`May 22nd 2017`): document deprecated behaviour in EasyBuild v3.2.0 (see :ref:`overview_deprecated`)
 * **release 20170512.01** (`May 12th 2017`): update release notes for EasyBuild v3.2.1 (see :ref:`release_notes_eb321`)

--- a/docs/Deprecated-functionality.rst
+++ b/docs/Deprecated-functionality.rst
@@ -31,6 +31,7 @@ For EasyBuild users:
 For authors of easyconfig files:
 
 * :ref:`depr_fftw_use_fma4`
+* :ref:`depr_sources_2_element_tuple`
 
 For developers of easyblocks:
 
@@ -56,6 +57,38 @@ The ``use_fma`` easyconfig parameter has been deprecated in favor of the equival
 Since it is only supported on systems with AMD processors that have the ``FMA4`` feature, it was replaced by
 the more fittingly named ``use_fma4`` parameter in EasyBuild v3.2.0.
 
+
+.. _depr_sources_2_element_tuple:
+
+Specifying source files as 2-element tuples to provide a custom extraction command
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* *deprecated since:* EasyBuild v3.3.0 (June 22nd 2017)
+* *will be removed in:* EasyBuild v4.0
+* *alternatives*: **use** ``extract_cmd`` **key in Python dictionary format instead**
+
+Specyfing a custom extraction command for a particular source file by using a 2-element tuple in ``sources``
+has been deprecated.
+
+Instead, a Python dictionary containing the ``filename`` and ``extract_cmd`` keys should be used instead,
+see :ref:`common_easyconfig_param_sources_alt`.
+
+So, this:
+
+.. code:: python
+
+    # source file is actually a gzipped tarball (filename should be .tar.gz)
+    # DEPRECATED FORMAT, don't use this anymore!
+    sources = [('example.gz', "tar xfvz %s")]
+
+should be replaced with:
+
+.. code:: python
+
+  sources = [{
+    'filename': 'example-%(version)s.gz',
+    'extract_cmd': "tar xfvz %s",  # source file is actually a gzipped tarball (filename should be .tar.gz)
+  }]
 
 .. _depr_copytree_function:
 

--- a/docs/Writing_easyconfig_files.rst
+++ b/docs/Writing_easyconfig_files.rst
@@ -106,12 +106,13 @@ This section includes an overview of some commonly used (optional) easyconfig pa
 
 .. _common_easyconfig_param_sources:
 
-Source files and patches
-~~~~~~~~~~~~~~~~~~~~~~~~
+Source files, patches and checksums
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * **sources**: list of source files (filenames only)
 * **source urls**: list of URLs where sources can be downloaded
 * **patches**: list of patch files to be applied (``.patch`` extension)
+* **checksums**: list of checksums for source and patch files
 
 Remarks:
 
@@ -123,21 +124,93 @@ Remarks:
   * unified diff format (``diff -ru``)
   * patched locations relative to unpacked sources
 
+* see :ref:`common_easyconfig_param_sources_checksums` for more information on ``checksums``
+* ``sources`` is usually specified as a list of strings representing filenames for source files,
+  but other formats are supported too, see :ref:`common_easyconfig_param_sources_alt`
+
 Example:
 
 .. code:: python
 
   name = 'HPL'
+  version = '2.2'
+
   [...]
+
   source_urls = ['http://www.netlib.org/benchmark/hpl']
-  sources = ['hpl-2.0.tar.gz']
+  sources = ['hpl-%(version)s.tar.gz']
 
   # fix Make dependencies, so parallel build also works
   patches = ['HPL_parallel-make.patch']
+
+  checksums = ['ac7534163a09e21a5fa763e4e16dfc119bc84043f6e6a807aba666518f8df440']
+
   [...]
 
 .. note:: Rather than hardcoding the version (and name) in the list of sources,
   a string template `%(version)s` can be used, see also :ref:`easyconfig_param_templates`.
+
+.. _common_easyconfig_param_sources_checksums:
+
+Checksums
+^^^^^^^^^
+
+Checksums for source files and patches can be provided via the ``checksums`` easyconfig parameter.
+
+EasyBuild does not enforce checksums to be available for all source files and patches.
+Provided checksums will be 'consumed' first for the specified sources (in order), and subsequently also for patches.
+
+Nevertheless, providing checksums for *all* source files and patches is highly recommended.
+
+If checksums are provided, the checksum of the corresponding source files and patches is verified to match.
+
+
+The ``checksums`` easyconfig parameter is usually defined as a list of strings.
+
+Until EasyBuild v3.3.0, only MD5 checksums could be provided through a list of strings.
+Since EasyBuild v3.3.0, the checksum type is determined by looking at the length of the string:
+
+* 32-character strings are considered to be MD5 checksums (``md5``)
+* 64-character strings are considered to be SHA256 checksums (``sha256``)
+* (other lengths will result in an error message)
+
+Other checksum types are also supported: ``adler32``, ``crc32``, ``sha1``, ``sha512``, ``size`` (filesize in bytes).
+To provide checksum values of a specific type, elements of the ``checksums`` list can also be 2-element tuples
+of the form ``('<checksum value>', '<checksum type>')``.
+
+The intention is to move towards making ``sha256`` the recommended and default checksum type.
+
+
+.. _common_easyconfig_param_sources_alt:
+
+Alternative formats for ``sources``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In some cases, it can be required to provide additional information next to the name of a source file,
+e.g., a custom extraction command (because the one derived from the file extension is not correct),
+or an altername filename that should be used to download the source file.
+
+This can be specified using a Python dictionary value in the ``sources`` easyconfig parameter.
+
+Since EasyBuild v3.3.0, three keys are supported:
+
+* ``filename`` (*mandatory*): filename of source file
+* ``download_filename``: filename that should be used when downloading this source file; the downloaded file will be
+  saved using the ``filename`` value
+* ``extract_cmd``: custom extraction command for this source file
+
+For example:
+
+.. code:: python
+
+  sources = [{
+    'filename': 'example-%(version)s.gz',
+    'download_filename': 'example.gz',  # provided source tarball is not versioned...
+    'extract_cmd': "tar xfvz %s",  # source file is actually a gzipped tarball (filename should be .tar.gz)
+  }]
+
+.. note:: Custom extraction commands can also be specified as a 2-element tuple, but this format has been deprecated
+          in favor of the Python dictionary format described above; see also :ref:`depr_sources_2_element_tuple`.
 
 .. _dependency_specs:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ copyright = '2012-2017, Ghent University, CC-BY-SA'
 # The short X.Y version.
 version = '3.3.0dev'  # this is meant to reference the version of EasyBuild
 # The full version, including alpha/beta/rc tags.
-release = '20170622.01'  # this is meant to reference the version of the documentation itself
+release = '20170623.01'  # this is meant to reference the version of the documentation itself
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
Updated docs for `checksums` and changes in https://github.com/hpcugent/easybuild-framework/pull/2223

preview at http://boegel-eb.readthedocs.io/en/sources_dict/Writing_easyconfig_files.html#source-files-patches-and-checksums and http://boegel-eb.readthedocs.io/en/sources_dict/Deprecated-functionality.html#depr-sources-2-element-tuple