### PR TITLE
pin to specific Sphinx version and older docutils for building docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,3 +18,4 @@ python:
   install:
       - method: pip
         path: .
+      - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+docutils<0.18
+sphinx==1.8.5


### PR DESCRIPTION
Building the docs fails currently on ReadTheDocs because of an incompatibility with the fixed Sphinx 1.8.5 version and the latest `docutils` that gets installed (details below).

<details>

```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/easybuild/envs/develop/lib/python3.7/site-packages/sphinx/cmd/build.py", line 304, in build_main
    app.build(args.force_all, filenames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/easybuild/envs/develop/lib/python3.7/site-packages/sphinx/application.py", line 341, in build
    self.builder.build_update()
  File "/home/docs/checkouts/readthedocs.org/user_builds/easybuild/envs/develop/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 347, in build_update
    len(to_build))
  File "/home/docs/checkouts/readthedocs.org/user_builds/easybuild/envs/develop/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 360, in build
    updated_docnames = set(self.read())
  File "/home/docs/checkouts/readthedocs.org/user_builds/easybuild/envs/develop/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 468, in read
    self._read_serial(docnames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/easybuild/envs/develop/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 490, in _read_serial
    self.read_doc(docname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/easybuild/envs/develop/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 534, in read_doc
    doctree = read_doc(self.app, self.env, self.env.doc2path(docname))
  File "/home/docs/checkouts/readthedocs.org/user_builds/easybuild/envs/develop/lib/python3.7/site-packages/sphinx/io.py", line 318, in read_doc
    pub.publish()
  File "/home/docs/checkouts/readthedocs.org/user_builds/easybuild/envs/develop/lib/python3.7/site-packages/docutils/core.py", line 219, in publish
    self.apply_transforms()
  File "/home/docs/checkouts/readthedocs.org/user_builds/easybuild/envs/develop/lib/python3.7/site-packages/docutils/core.py", line 200, in apply_transforms
    self.document.transformer.apply_transforms()
  File "/home/docs/checkouts/readthedocs.org/user_builds/easybuild/envs/develop/lib/python3.7/site-packages/sphinx/transforms/__init__.py", line 90, in apply_transforms
    Transformer.apply_transforms(self)
  File "/home/docs/checkouts/readthedocs.org/user_builds/easybuild/envs/develop/lib/python3.7/site-packages/docutils/transforms/__init__.py", line 171, in apply_transforms
    transform.apply(**kwargs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/easybuild/envs/develop/lib/python3.7/site-packages/sphinx/transforms/__init__.py", line 245, in apply
    apply_source_workaround(n)
  File "/home/docs/checkouts/readthedocs.org/user_builds/easybuild/envs/develop/lib/python3.7/site-packages/sphinx/util/nodes.py", line 94, in apply_source_workaround
    for classifier in reversed(node.parent.traverse(nodes.classifier)):
TypeError: 'generator' object is not reversible
```

</details>

The problem is discussed in https://github.com/sphinx-doc/sphinx/issues/9727, pinning to an old `docutils` version should fix the problem. Sphinx is also being pinned to 1.8.5, since that's the default for old ReadTheDocs projects (see https://docs.readthedocs.io/en/stable/builds.html#python).