### PR TITLE
update overview of deprecated toolchains for EasyBuild v4.5.0

### DIFF
--- a/docs/Deprecated-easyconfigs.rst
+++ b/docs/Deprecated-easyconfigs.rst
@@ -64,10 +64,12 @@ Deprecated toolchains
 Overview of deprecated toolchains:
 
 * :ref:`deprecated_easyconfigs_toolchains_foss`
+* :ref:`deprecated_easyconfigs_toolchains_gcc`
 * :ref:`deprecated_easyconfigs_toolchains_gompi`
 * :ref:`deprecated_easyconfigs_toolchains_goolf`
 * :ref:`deprecated_easyconfigs_toolchains_ictce`
 * :ref:`deprecated_easyconfigs_toolchains_intel`
+* :ref:`deprecated_easyconfigs_toolchains_iomkl`
 
 
 .. _deprecated_easyconfigs_toolchains_foss:
@@ -75,11 +77,23 @@ Overview of deprecated toolchains:
 ``foss`` toolchain
 ~~~~~~~~~~~~~~~~~~
 
-* *deprecated since:* EasyBuild v3.9.4
-* *will be archived in:* EasyBuild v4.0.0
+* *deprecated since:* EasyBuild v4.5.0
+* *will be archived in:* EasyBuild v5.0.0
 
 The oldest versions of the ``foss`` toolchain have been deprecated,
-which currently includes any version older than ``foss/2016a``.
+which currently includes any version older than ``foss/2019a``.
+
+
+.. _deprecated_easyconfigs_toolchains_gcc:
+
+``GCCcore`` and ``GCC`` toolchains
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* *deprecated since:* EasyBuild v4.5.0
+* *will be archived in:* EasyBuild v5.0.0
+
+The oldest versions of the ``GCCcore`` and ``GCC`` toolchains have been deprecated,
+which currently includes any version older than ``8.0``.
 
 
 .. _deprecated_easyconfigs_toolchains_gompi:
@@ -87,12 +101,11 @@ which currently includes any version older than ``foss/2016a``.
 ``gompi`` toolchain
 ~~~~~~~~~~~~~~~~~~~
 
-* *deprecated since:* EasyBuild v3.8.0
-* *will be archived in:* EasyBuild v4.0.0
+* *deprecated since:* EasyBuild v4.5.0
+* *will be archived in:* EasyBuild v5.0.0
 
 Versions of the ``gompi`` toolchain that were used as a subtoolchain for a deprecated toolchain
-have also been deprecated; this includes ``gompi`` toolchain versions that match ``1.*``, and any version
-older than ``gompi/2016a`` (the latter only since EasyBuild v3.9.4).
+have also been deprecated; this includes ``gompi`` toolchain versions older than ``gompi/2019a``.
 
 
 .. _deprecated_easyconfigs_toolchains_goolf:
@@ -101,7 +114,7 @@ older than ``gompi/2016a`` (the latter only since EasyBuild v3.9.4).
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * *deprecated since:* EasyBuild v3.8.0
-* *will be archived in:* EasyBuild v4.0.0
+* *archived in:* EasyBuild v4.0.0
 
 The ``goolf`` and ``goolfc`` toolchains have been deprecated,
 since they are superseded by the :ref:`common_toolchains_foss` and ``fosscuda`` toolchains, respectively.
@@ -116,7 +129,7 @@ except that ``binutils`` is also included as a companion to ``GCC(core)`` in the
 ~~~~~~~~~~~~~~~~~~~
 
 * *deprecated since:* EasyBuild v3.8.0
-* *will be archived in:* EasyBuild v4.0.0
+* *archived in:* EasyBuild v4.0.0
 
 The ``ictce`` toolchain has been deprecated, since it is superseded by the :ref:`common_toolchains_intel`.
 
@@ -127,17 +140,28 @@ for the Intel compilers) in the ``intel`` toolchain.
 
 .. _deprecated_easyconfigs_toolchains_intel:
 
-Oldest versions of the ``iccifort``, ``iimpi`` and ``intel`` toolchains
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``iccifort``, ``iimpi`` and ``intel`` toolchains
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* *deprecated since:* EasyBuild v3.8.0
-* *will be archived in:* EasyBuild v4.0.0
+* *deprecated since:* EasyBuild v4.5.0
+* *will be archived in:* EasyBuild v5.0.0
 
-The oldest versions of the ``iccifort``, ``iimpi`` and :ref:`common_toolchains_intel` have been deprecated,
-since they are no longer considered relevant for recent systems.
+The oldest versions of the ``iccifort``, ``iimpi`` and :ref:`common_toolchains_intel` have been deprecated.
 
-More specifically, deprecated versions include:
+Deprecated versions include:
 
-* ``iccifort`` versions older than ``2016.1.150``
-* ``iimpi`` versions older than ``2016.01``, except version ``8.1.5-*``
-* ``intel`` versions older than ``2016a``
+* ``iccifort`` versions older than ``2019.0``
+* ``iimpi`` versions older than ``2019a``
+* ``intel`` versions older than ``2019a``
+
+
+.. _deprecated_easyconfigs_toolchains_iomkl:
+
+``iompi`` and ``iomkl`` toolchains
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* *deprecated since:* EasyBuild v4.5.0
+* *will be archived in:* EasyBuild v5.0.0
+
+The oldest versions of the ``iompi`` and ``iomkl`` toolchains have been deprecated,
+which currently includes any version older than ``iompi/2019a`` and ``iomkl/2019a``.


### PR DESCRIPTION
cfr. https://github.com/easybuilders/easybuild-framework/pull/3876